### PR TITLE
build: set up self-test workflow

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -22,9 +22,20 @@ jobs:
           npm run lint
           npm run package
           npm run test
+  self-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Sonarqube
+        uses: ./
+        with:
+          ca-cert: ${{ secrets.MTLS_CACERT }}
+          client-cert: ${{ secrets.MTLS_CERT }}
+          client-key: ${{ secrets.MTLS_KEY }}
+          token: ${{ secrets.SONAR_TOKEN }}
   release:
     runs-on: ubuntu-latest
-    needs: [build]
+    needs: [build, self-test]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,3 +23,16 @@ jobs:
           npm run test
       - name: Check for changes (fail if we forgot to update lib output)
         run: git diff --quiet dist
+  self-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Sonarqube
+        uses: ./
+        with:
+          ca-cert: ${{ secrets.MTLS_CACERT }}
+          client-cert: ${{ secrets.MTLS_CERT }}
+          client-key: ${{ secrets.MTLS_KEY }}
+          token: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
To avoid any breaking releases of the action, we should run it on itself.