### PR TITLE
Add extra logging

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,8 @@ async function run(): Promise<void> {
     let sonarHost =
       'http://sonarqube-default-sonarqube-0.sonarqube-default-sonarqube.default.svc.cluster.local:9000';
     const labels = process.env.RUNNER_LABELS;
+    info(`Running on ${process.env.RUNNER_NAME}`);
+    info(`Found runner labels: ${labels}`);
     if (!labels?.includes('self-hosted')) {
       info('Detected running on GH runners');
       if (!inputs.caCert) {


### PR DESCRIPTION
Some runners are getting detected as running in a hosted runner incorrectly. This logging will give some more insights into why.