### PR TITLE
chore: Optimize npm dependency installation

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -16,7 +16,7 @@ jobs:
           restore-keys: |
             npm-
       - run: |
-          npm ci
+          npm ci --ignore-scripts
           npm run build
           npm run format-check
           npm run lint

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/cache@v5
         with:
           path: ~/.npm
@@ -58,7 +58,7 @@ jobs:
   self-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Sonarqube
         uses: ./
         with:
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build, self-test]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - uses: tradeshift/actions-semantic-release@v2

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/cache@v5
         with:
           path: ~/.npm
@@ -58,7 +58,7 @@ jobs:
   self-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Sonarqube
         uses: ./
         with:
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build, self-test]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: tradeshift/actions-semantic-release@v2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,7 @@ jobs:
           restore-keys: |
             npm-
       - run: |
-          npm ci
+          npm ci --ignore-scripts
           npm run build
           npm run format-check
           npm run lint

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/cache@v5
@@ -24,7 +24,7 @@ jobs:
   self-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Sonarqube
@@ -40,7 +40,7 @@ jobs:
   semantic-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Dry-run release

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/cache@v5
@@ -24,7 +24,7 @@ jobs:
   self-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Sonarqube
@@ -36,3 +36,20 @@ jobs:
           token: ${{ secrets.SONAR_TOKEN }}
           args: |
             -Dsonar.exclusions=dist/**/*.js
+  
+  semantic-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Dry-run release
+        uses: tradeshift/actions-semantic-release@v2
+        id: semantic-release
+        with:
+          dry_run: true
+          check_name: Semantic release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Lint commit messages
+        uses: tradeshift/commitlint-github-action@v5


### PR DESCRIPTION
This PR replaces `npm install` and `npm ci` with `npm ci --ignore-scripts` in both Dockerfiles and YAML files (CI workflows, etc.). This improves build security, reproducibility, and speed by avoiding arbitrary scripts during install.